### PR TITLE
更新 v2ray 版本为 v4.28.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ LABEL maintainer "sebs sebsclub@outlook.com"
 ARG TZ="Asia/Shanghai"
 
 ENV TZ ${TZ}
-ENV V2RAY_VERSION v4.25.1 
+ENV V2RAY_VERSION v4.28.2
 ENV V2RAY_LOG_DIR /var/log/v2ray
 ENV V2RAY_CONFIG_DIR /etc/v2ray/
 ENV V2RAY_DOWNLOAD_URL https://github.com/v2ray/v2ray-core/releases/download/${V2RAY_VERSION}/v2ray-linux-64.zip


### PR DESCRIPTION
最近配置的时候发现 v4.25.1 的 v2rayCore 似乎不兼容客户端上 v2rayCore v4.30.0 了，自己在 Docker 容器中更新了 v4.28.2 版本以后即能正常工作。希望作者能够尽快更新。